### PR TITLE
travis-ci implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: php
+matrix:
+  include:
+    - php: '7.2'
+      env: PHPC_WPC=1
+    - php: '7.1'
+      env: PHPC_WPC=1
+    - php: '7.0'
+      env: PHPC_WPC=1
+    - php: '5.6'
+      env: PHPC_WPC=1
+    - php: '5.5'
+      env: PHPC_WPC=1
+    - php: '5.4'
+      env: PHPC_WPC=1
+    - php: 5.3
+      dist: precise
+      env: PHPC_WPC=1
+before_script:
+    - pear install pear/PHP_CodeSniffer
+    - export SNIFFS_DIR=/tmp/sniffs
+    - |
+      if [[ "$PHPC_WPC" == "1" ]]; then
+        git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR
+        git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility
+        phpenv rehash
+      fi
+script:
+    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    - |
+      if [[ "$PHPC_WPC" == "1" ]]; then
+        phpcs --config-set installed_paths $SNIFFS_DIR/PHPCompatibility
+        phpcs -p -s -v -n . --standard=PHPCompatibility --extensions=php
+        phpcs --config-set installed_paths $SNIFFS_DIR
+        phpcs -p -s -v -n . --standard=WordPress-Core --extensions=php
+      fi
+notifications:
+    email: false


### PR DESCRIPTION
This is up to you if you want it.

I usually set up travis-ci on my projects to do the dirty work as always. This simple .yml will tell travis to check 5.2 - 7.3 php compatibility + again WordPress Coding standards for you :), for the time being the build passes fine ^_^.